### PR TITLE
Time data for node and edge creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ generation:
     # add id field to all schema types
     field_for_id: true
     # add creation date and last update date field(s) to all schema types
+    generate_datetime: false
     field_for_creation_date: true
     field_for_last_update_date: true
     # add reverse edges for traversal

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ generation:
     add_mutation_type: true
     # add id field to all schema types
     field_for_id: true
+    # add creation date and last update date field(s) to all schema types
+    field_for_creation_date: true
+    field_for_last_update_date: true
     # add reverse edges for traversal
     reverse_edges: true
     # add edge types

--- a/graphql-api-generator/generator.py
+++ b/graphql-api-generator/generator.py
@@ -68,6 +68,14 @@ def run(schema: GraphQLSchema, config: dict):
         if config.get('generation').get('field_for_id'):
             schema = add_id_to_types(schema)
 
+        # add creationDate
+        if config.get('generation').get('field_for_creation_date'):
+            schema = add_creation_date_to_types(schema)
+
+        # add lastUpdateDate
+        if config.get('generation').get('field_for_last_update_date'):
+            schema = add_last_update_date_to_types(schema)
+
         # add reverse edges for traversal
         if config.get('generation').get('reverse_edges'):
             schema = add_reverse_edges(schema)

--- a/graphql-api-generator/generator.py
+++ b/graphql-api-generator/generator.py
@@ -144,16 +144,6 @@ def run(schema: GraphQLSchema, config: dict):
 
 
 def validate_names(schema: GraphQLSchema, validate):
-    # scalars
-    if validate.get('scalar_names'):
-        # type names
-        f = string_transforms.get(validate.get('scalar_names'))
-        if f is None:
-            raise Exception('Unrecognized option: ' + validate.get('type_names'))
-        for type_name, _type in schema.type_map.items():
-            if is_sclara_type(_type):
-                if f(type_name) != type_name:
-                    raise Exception(f'Scalar "{type_name}" does not follow {validate.get("scalar_names")}')
 
     # types and interfaces
     if validate.get('type_names'):
@@ -196,12 +186,6 @@ def validate_names(schema: GraphQLSchema, validate):
 
 
 def transform_names(schema: GraphQLSchema, transform):
-    # scalar
-    if transform.get('scalar_names'):
-        if transform.get('scalar_names') in string_transforms:
-            transform_scalars(schema, string_transforms[transform.get('scalar_names')])
-        else:
-            raise Exception('Unsupported scalar name transform: ' + transform.get('scalar_names'))
 
     # types and interfaces
     if transform.get('type_names'):
@@ -227,16 +211,6 @@ def transform_names(schema: GraphQLSchema, transform):
     # comments
     if transform.get('drop_comments'):
         drop_comments(schema)
-
-
-def transform_scalars(schema, transform):
-    type_names = set(schema.type_map.keys())
-    for type_name in type_names:
-        _type = schema.type_map[type_name]
-        if is_scalar_type(_type):
-            schema.type_map.pop(type_name)
-            _type.name = transform(type_name)
-            schema.type_map[_type.name] = _type
 
 
 def transform_types(schema, transform):

--- a/graphql-api-generator/generator.py
+++ b/graphql-api-generator/generator.py
@@ -82,7 +82,7 @@ def run(schema: GraphQLSchema, config: dict):
 
         # add edge types
         if config.get('generation').get('edge_types') or config.get('generation').get('create_edge_objects'):
-            schema = add_edge_objects(schema)
+            schema = add_edge_objects(schema, config.get('generation').get('field_for_creation_date'), config.get('generation').get('field_for_last_update_date'))
         if config.get('generation').get('fields_for_edge_types'):
             raise UnsupportedOperation('{0} is currently not supported'.format('fields_for_edge_types'))
 

--- a/graphql-api-generator/resources/config.yml
+++ b/graphql-api-generator/resources/config.yml
@@ -12,6 +12,9 @@ generation:
     add_mutation_type: true
     # add id field to all schema types
     field_for_id: true
+    # add creation date and last update date field(s) to all schema types
+    field_for_creation_date: false
+    field_for_last_update_date: false
     # add reverse edges for traversal
     reverse_edges: true
     # add edge types

--- a/graphql-api-generator/resources/config.yml
+++ b/graphql-api-generator/resources/config.yml
@@ -14,8 +14,8 @@ generation:
     field_for_id: true
     # add creation date and last update date field(s) to all schema types
     generate_datetime: false
-    field_for_creation_date: false
-    field_for_last_update_date: false
+    field_for_creation_date: true
+    field_for_last_update_date: true
     # add reverse edges for traversal
     reverse_edges: true
     # add edge types

--- a/graphql-api-generator/resources/config.yml
+++ b/graphql-api-generator/resources/config.yml
@@ -13,6 +13,7 @@ generation:
     # add id field to all schema types
     field_for_id: true
     # add creation date and last update date field(s) to all schema types
+    generate_datetime: false
     field_for_creation_date: false
     field_for_last_update_date: false
     # add reverse edges for traversal

--- a/graphql-api-generator/test/all_tests.py
+++ b/graphql-api-generator/test/all_tests.py
@@ -50,3 +50,69 @@ class Tests(TestCase):
         ''')
         schema_out = generator.run(schema_in, config)
         assert compare.is_equals_schema(schema_out, expected)
+
+    def test_add_crationDate_1(self):
+        schema_in = build_schema('''
+            type Test
+        ''')
+        config = {'generation': {'field_for_creation_date': True}}
+        expected = build_schema('''
+           scalar DateTime
+           type Test {
+               _creationDate: DateTime!
+           }
+        ''')
+        schema_out = run(schema_in, config)
+        assert compare.is_equals_schema(schema_out, expected)
+
+    def test_add_lastUpdateDate_1(self):
+        schema_in = build_schema('''
+           type Test
+        ''')
+        config = {'generation': {'field_for_last_update_date': True}}
+        expected = build_schema('''
+           scalar DateTime
+           type Test {
+               _lastUpdateDate: DateTime
+           }
+        ''')
+        schema_out = run(schema_in, config)
+        assert compare.is_equals_schema(schema_out, expected)
+
+    def test_datetime_scalar_1(self):
+        schema_in = build_schema('''
+            type datetime_test
+        ''')
+        config = {'generation': {'generate_datetime': True}}
+        try:
+            run(schema_in, config)
+            assert True
+        except:
+            assert False
+
+    def test_datetime_scalar_2(self):
+        schema_in = build_schema('''
+            scalar DateTime
+            type datetime_test { date: DateTime! }
+        ''')
+        config = {'generation': {'generate_datetime': True}}
+        try:
+            run(schema_in, config)
+            assert True
+        except:
+            assert False
+
+    def test_datetime_scalar_3(self):
+        schema_in = build_schema('''
+            type DateTime {
+                date: String!
+                time: String!
+            }
+            type datetime_test { date: DateTime! }
+        ''')
+        config = {'generation': {'generate_datetime': True}}
+        try:
+            run(schema_in, config)
+            assert False
+        except:
+            assert True

--- a/graphql-api-generator/test/all_tests.py
+++ b/graphql-api-generator/test/all_tests.py
@@ -62,7 +62,7 @@ class Tests(TestCase):
                _creationDate: DateTime!
            }
         ''')
-        schema_out = run(schema_in, config)
+        schema_out = generator.run(schema_in, config)
         assert compare.is_equals_schema(schema_out, expected)
 
     def test_add_lastUpdateDate_1(self):
@@ -76,7 +76,7 @@ class Tests(TestCase):
                _lastUpdateDate: DateTime
            }
         ''')
-        schema_out = run(schema_in, config)
+        schema_out = generator.run(schema_in, config)
         assert compare.is_equals_schema(schema_out, expected)
 
     def test_datetime_scalar_1(self):
@@ -97,7 +97,7 @@ class Tests(TestCase):
         ''')
         config = {'generation': {'generate_datetime': True}}
         try:
-            run(schema_in, config)
+            generator.run(schema_in, config)
             assert True
         except:
             assert False
@@ -112,7 +112,7 @@ class Tests(TestCase):
         ''')
         config = {'generation': {'generate_datetime': True}}
         try:
-            run(schema_in, config)
+            generator.run(schema_in, config)
             assert False
         except:
             assert True

--- a/graphql-api-generator/utils/utils.py
+++ b/graphql-api-generator/utils/utils.py
@@ -109,9 +109,9 @@ def add_creation_date_to_types(schema: GraphQLSchema):
         if not is_schema_defined_type(_type):
             continue
         if is_interface_type(_type):
-            make += f'extend interface {_type.name} {{ _creationDate: Date! }} '
+            make += f'extend interface {_type.name} {{ _creationDate: DateTime! }} '
         else:
-            make += f'extend type {_type.name} {{ _creationDate: Date! }} '
+            make += f'extend type {_type.name} {{ _creationDate: DateTime! }} '
     return add_to_schema(schema, make)
 
 
@@ -126,9 +126,9 @@ def add_last_update_date_to_types(schema: GraphQLSchema):
         if not is_schema_defined_type(_type):
             continue
         if is_interface_type(_type):
-            make += f'extend interface {_type.name} {{ _lastUpdateDate: Date }} '
+            make += f'extend interface {_type.name} {{ _lastUpdateDate: DateTime }} '
         else:
-            make += f'extend type {_type.name} {{ _lastUpdateDate: Date }} '
+            make += f'extend type {_type.name} {{ _lastUpdateDate: DateTime }} '
     return add_to_schema(schema, make)
 
 

--- a/graphql-api-generator/utils/utils.py
+++ b/graphql-api-generator/utils/utils.py
@@ -560,8 +560,14 @@ def get_field_annotations(field: GraphQLField):
     return " ".join(annotation_fields)
 
 
-def add_edge_objects(schema: GraphQLSchema):
+def add_edge_objects(schema: GraphQLSchema, field_for_creation_date, field_for_last_update_date):
     make = ''
+    creation_date_string = ''
+    last_update_date_string = ''
+    if field_for_creation_date:
+        creation_date_string = '_creationDate: Date!'
+    if field_for_last_update_date:
+        last_update_date_string = '_lastUpdateDate: Date'
     for _type in schema.type_map.values():
         if not is_schema_defined_type(_type) or is_interface_type(_type):
             continue
@@ -573,7 +579,7 @@ def add_edge_objects(schema: GraphQLSchema):
             for t in connected_types:
                 edge_from = f'{capitalize(field_name)}EdgeFrom{t.name}'
                 annotations = get_field_annotations(field)
-                make += f'type _{edge_from} {{id:ID! source: {t.name}! target: {inner_field_type}! {annotations}}}\n'
+                make += f'type _{edge_from} {{id:ID! source: {t.name}! target: {inner_field_type}! {creation_date_string} {last_update_date_string} {annotations}}}\n'
 
     schema = add_to_schema(schema, make)
     return schema

--- a/graphql-api-generator/utils/utils.py
+++ b/graphql-api-generator/utils/utils.py
@@ -98,6 +98,40 @@ def add_id_to_types(schema: GraphQLSchema):
     return add_to_schema(schema, make)
 
 
+def add_creation_date_to_types(schema: GraphQLSchema):
+    """
+    Extend all object types in the schema with an creationDate field.
+    :param schema:
+    :return:
+    """
+    make = ''
+    for _type in schema.type_map.values():
+        if not is_schema_defined_type(_type):
+            continue
+        if is_interface_type(_type):
+            make += f'extend interface {_type.name} {{ _creationDate: Date! }} '
+        else:
+            make += f'extend type {_type.name} {{ _creationDate: Date! }} '
+    return add_to_schema(schema, make)
+
+
+def add_last_update_date_to_types(schema: GraphQLSchema):
+    """
+    Extend all object types in the schema with an lastUpdateDate field.
+    :param schema:
+    :return:
+    """
+    make = ''
+    for _type in schema.type_map.values():
+        if not is_schema_defined_type(_type):
+            continue
+        if is_interface_type(_type):
+            make += f'extend interface {_type.name} {{ _lastUpdateDate: Date }} '
+        else:
+            make += f'extend type {_type.name} {{ _lastUpdateDate: Date }} '
+    return add_to_schema(schema, make)
+
+
 def copy_wrapper_structure(_type: GraphQLType, original: GraphQLType):
     """
     Copy the wrapper structure of original to _type.


### PR DESCRIPTION
Added support for automatic enforcement of creationDate and lastUpdateDate fields to nodes and edges upon request from other projects.
Also allows automatic definition of the DateTime scalar if requested/needed.

Some of the older tests seems to give errors (complains about object not having args)?
The change to add_edge_objects is not the neatest, but it gets the job done.